### PR TITLE
Updated for RSpec 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,7 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in active_record_ignored_attributes.gemspec
 gemspec
+
+group :test do
+  gem 'byebug'
+end

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,10 @@
 ActiveRecord Ignored Attributes
 ===============================
 
-Adds various behavior to Active Record models relating to the model's attributes: 
+Updated to work with RSpec 3.x+ and ActiveRecord 4.x+
+=====================================================
+
+Adds various behavior to Active Record models relating to the model's attributes:
 
 * Allows you to compare Active Record objects based on their *attributes*, which often makes more sense than the built-in `==` operator (which does its comparisons based on the `id` attribute alone! — not always what you want!)
 * You can configure which attributes, if any, should be excluded from the comparison
@@ -102,7 +105,7 @@ Now that you've declared which attributes you don't really care about, how about
 
     # Compared to:
     address.inspect                            # => "#<Address id: 1, name: nil, address: nil, city: nil, state: nil, postal_code: nil, country: nil, created_at: \"2011-08-19 18:07:39\", updated_at: \"2011-08-19 18:07:39\">"
-  
+
 But that is a lot to type every time. If you want inspect to *always* be more readable, you can override the ActiveRecord default like this:
 
     class Address < ActiveRecord::Base
@@ -227,7 +230,7 @@ Questions and Ideas
 
 Possible improvements:
 
-* Allow the default to be overridden with a class macro like `ignore_for_attributes_eql :last_signed_in_at, :updated_at` 
+* Allow the default to be overridden with a class macro like `ignore_for_attributes_eql :last_signed_in_at, :updated_at`
 
 Also, perhaps you want to set the default ignored attributes for a model but still wish to be able to override these defaults as needed...
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,8 +1,8 @@
 ActiveRecord Ignored Attributes
 ===============================
 
-Updated to work with RSpec 3.x+ and ActiveRecord 4.x+
-=====================================================
+Updated to work with RSpec 3.x
+
 
 Adds various behavior to Active Record models relating to the model's attributes:
 

--- a/active_record_ignored_attributes.gemspec
+++ b/active_record_ignored_attributes.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = %q{Allows you to compare Active Record objects based on their *attributes* (with same_as?), to exclude some attributes from being used in comparison, and adds improved inspect method}
   s.description = s.summary
 
-  s.add_dependency             'activerecord', '~> 4'
+  s.add_dependency             'activerecord'
   s.add_dependency             'facets'
 
   s.add_development_dependency 'rspec', '~> 3'

--- a/active_record_ignored_attributes.gemspec
+++ b/active_record_ignored_attributes.gemspec
@@ -11,16 +11,14 @@ Gem::Specification.new do |s|
   s.summary     = %q{Allows you to compare Active Record objects based on their *attributes* (with same_as?), to exclude some attributes from being used in comparison, and adds improved inspect method}
   s.description = s.summary
 
-  s.add_dependency             'activerecord'
+  s.add_dependency             'activerecord', '~> 4'
   s.add_dependency             'facets'
 
-  s.add_development_dependency 'rspec'
- #s.add_development_dependency 'rcov'
+  s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'mysql2', '~>0.2.11'
   s.add_development_dependency 'rr'
-  s.add_development_dependency 'activesupport'
-  s.add_development_dependency 'ruby-debug19'
+  s.add_development_dependency 'activesupport', '~> 4'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/active_record_ignored_attributes/matchers/be_same_as.rb
+++ b/lib/active_record_ignored_attributes/matchers/be_same_as.rb
@@ -3,7 +3,7 @@ RSpec::Matchers.define :be_same_as do |expected|
     actual.same_as?(expected)
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
    #%(#{actual.inspect_without_ignored_attributes} was expected to have the same attributes as\n) +
    #%(#{expected.inspect_without_ignored_attributes})
 
@@ -15,7 +15,7 @@ RSpec::Matchers.define :be_same_as do |expected|
     %(     got: #{actual.inspect_with(attr_names_that_differed)})
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     %(         expected: #{expected.inspect}\n) +
     %(to not be same_as: #{actual.inspect})
   end

--- a/lib/active_record_ignored_attributes/matchers/have_attribute_values.rb
+++ b/lib/active_record_ignored_attributes/matchers/have_attribute_values.rb
@@ -3,12 +3,12 @@ RSpec::Matchers.define :have_attribute_values do |expected|
     actual.has_attribute_values?(expected)
   end
 
-  failure_message_for_should do |actual|
+  failure_message do |actual|
     %(expected: #{expected.symbolize_keys.inspect}\n) +
     %(     got: #{actual.attributes.slice(*expected.stringify_keys.keys).symbolize_keys.inspect})
   end
 
-  failure_message_for_should_not do |actual|
+  failure_message_when_negated do |actual|
     %(expected #{actual.inspect}\n) +
     %(not to have attribute values #{expected.symbolize_keys.inspect})
   end

--- a/lib/active_record_ignored_attributes/version.rb
+++ b/lib/active_record_ignored_attributes/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecordIgnoredAttributes
   def self.version
-    "0.0.4"
+    "0.0.5"
   end
 end

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -5,28 +5,28 @@ describe Address do
     let(:address) { Address.create! }
     it 'should not include any of the ignored attributes' do
       address.attributes_without_ignored_attributes.tap do |attributes|
-        attributes.should be_a(Hash)
-        attributes.should_not have_key('id')
-        attributes.should_not have_key('created_at')
-        attributes.should_not have_key('updated_at')
-        attributes.should_not have_key('name')
+        expect(attributes.class).to eq(Hash)
+        expect(attributes).to_not have_key('id')
+        expect(attributes).to_not have_key('created_at')
+        expect(attributes).to_not have_key('updated_at')
+        expect(attributes).to_not have_key('name')
       end
 
       # Plain old 'attributes', on the other hand, does include them
       address.attributes.tap do |attributes|
-        attributes.should be_a(Hash)
-        attributes.should have_key('id')
-        attributes.should have_key('created_at')
-        attributes.should have_key('updated_at')
+        expect(attributes.class).to eq(Hash)
+        expect(attributes).to have_key('id')
+        expect(attributes).to have_key('created_at')
+        expect(attributes).to have_key('updated_at')
       end
     end
 
     it 'should include all of the non-ignored attributes' do
       address.attributes_without_ignored_attributes.tap do |attributes|
-        attributes.should be_a(Hash)
+        expect(attributes.class).to eq(Hash)
         [:address, :city, :state, :postal_code, :country].each do |attr_name|
           #puts "attributes.has_key?(#{attr_name})=#{attributes.has_key?(attr_name)}"
-          attributes.should have_key(attr_name.to_s)
+          expect(attributes).to have_key(attr_name.to_s)
         end
       end
     end

--- a/spec/has_attribute_values_spec.rb
+++ b/spec/has_attribute_values_spec.rb
@@ -6,18 +6,18 @@ describe Address do
 
     it 'should return true if passed {}' do
       a = Address.new(        name: 'A', address: 'The Same Address', city: "Don't care")
-      a.has_attribute_values?({}).should be_true
+      expect(a.has_attribute_values?({})).to be(true)
     end
 
     it 'should return true if the given attributes have the given values' do
       a = Address.new(        name: 'A', address: 'The Same Address', city: "Don't care")
-      a.has_attribute_values?(name: 'A', address: 'The Same Address').should be_true
+      expect(a.has_attribute_values?(name: 'A', address: 'The Same Address')).to be(true)
     end
 
     it 'should return false if any of the given attributes have different values than given' do
       a = Address.new(        name: 'A', address: 'The Same Address', city: "Don't care")
-      a.has_attribute_values?(name: 'A', address: 'The Same Address', city: "I do care after all").should be_false
-      a.has_attribute_values?(name: 'B', address: 'The Same Address').should be_false
+      expect(a.has_attribute_values?(name: 'A', address: 'The Same Address', city: "I do care after all")).to be(false)
+      expect(a.has_attribute_values?(name: 'B', address: 'The Same Address')).to be(false)
     end
   end
 end

--- a/spec/inspect_spec.rb
+++ b/spec/inspect_spec.rb
@@ -4,22 +4,23 @@ describe Address do
   describe 'inspect_without_ignored_attributes' do
     let(:address) { Address.create }
     it "should include id" do
-      address.inspect_without_ignored_attributes.should     match(/id:/)
+      expect(address.inspect_without_ignored_attributes).to match(/id:/)
     end
     it "should not include the other ignored_attributes" do
-      address.inspect_without_ignored_attributes.should_not match(/name:/)
-      address.inspect_without_ignored_attributes.should_not match(/created_at:/)
+      expect(address.inspect_without_ignored_attributes).to_not match(/name:/)
+      expect(address.inspect_without_ignored_attributes).to_not match(/created_at:/)
     end
     it "should match what we expect it to look like" do
-      address.inspect_without_ignored_attributes.should match(/#<Address id: \d+, address: nil, city: nil, country: nil, postal_code: nil, state: nil>/)
-      address.original_inspect.should                   match(/#<Address id: \d+, .* created_at: ".*", updated_at: ".*">/)
+      m = /Addressid:\d+, address:nil, city:nil, country:nil, postal_code:nil, state:nil/
+      expect(address.inspect_without_ignored_attributes.gsub(/[<>#]/,'').gsub(/\s/, '').split(/,/).sort.to_s.gsub(/["\]\[]/,'')).to match(m)
+      expect(address.original_inspect).to match(/#<Address id: \d+, .* created_at: ".*", updated_at: ".*">/)
     end
   end
 
   describe 'inspect' do
     let(:address) { Address.create }
     specify do
-      address.inspect.should match(/{Address id: \d+, name: nil, address: nil, city: nil, state: nil, postal_code: nil, country: nil}/)
+      expect(address.inspect).to match(/{Address id: \d+, name: nil, address: nil, city: nil, state: nil, postal_code: nil, country: nil}/)
     end
   end
 end

--- a/spec/matchers/have_attribute_values_spec.rb
+++ b/spec/matchers/have_attribute_values_spec.rb
@@ -6,30 +6,30 @@ describe "have_attribute_values" do
   it "delegates to has_attribute_values?" do
     object, other = Object.new, Object.new
     mock(object).has_attribute_values?(other) { true }
-    object.should have_attribute_values(other)
+    expect(object).to have_attribute_values(other)
   end
 
   it 'matches when it should match' do
     object = Address.new(                 name: 'A', address: 'The Same Address', city: "Don't care")
     expect do
-      (object.should have_attribute_values name: 'A', address: 'The Same Address').should be_true
+      expect(object).to have_attribute_values(name: 'A', address: 'The Same Address')
     end.to_not raise_error
   end
 
-  it "reports a nice failure message for should" do
+  it "reports a nice failure message for to" do
     object = Address.new(                 name: 'A', address: 'The Same Address', city: "Don't care")
     expect do
-      object.should have_attribute_values name: 'A', address: 'A Slightly Different Address'
+      expect(object).to have_attribute_values name: 'A', address: 'A Slightly Different Address'
     end.to raise_error(<<-End.strip_heredoc.chomp)
     expected: {:name=>"A", :address=>"A Slightly Different Address"}
          got: {:name=>"A", :address=>"The Same Address"}
     End
   end
 
-  it "reports a nice failure message for should_not" do
+  it "reports a nice failure message for to_not" do
     object = Address.new(                 name: 'A', address: 'The Same Address', city: "Don't care")
     expect do
-      object.should_not have_attribute_values name: 'A', address: 'The Same Address'
+      expect(object).to_not have_attribute_values(name: 'A', address: 'The Same Address')
     end.to raise_error(<<-End.strip_heredoc.chomp)
     expected {Address id: nil, name: "A", address: "The Same Address", city: "Don't care", state: nil, postal_code: nil, country: nil}
     not to have attribute values {:name=>"A", :address=>"The Same Address"}

--- a/spec/matchers/same_as_spec.rb
+++ b/spec/matchers/same_as_spec.rb
@@ -5,23 +5,23 @@ describe "be_same_as" do
   it "delegates to same_as?" do
     object, other = Object.new, Object.new
     mock(object).same_as?(other) { true }
-    object.should be_same_as(other)
+    expect(object).to be_same_as(other)
   end
 
-  it "reports a nice failure message for should" do
+  it "reports a nice failure message for to" do
     object, other = Address.new(address: 'A Street'), Address.new(address: 'B Street')
     expect do
-      object.should be_same_as(other)
+      expect(object).to be_same_as(other)
     end.to raise_error(<<-End.strip_heredoc.chomp)
     expected: #<Address address: "B Street">
          got: #<Address address: "A Street">
     End
   end
 
-  it "reports a nice failure message for should_not" do
+  it "reports a nice failure message for to_not" do
     object, other = Address.new(address: 'A Street'), Address.new(address: 'A Street')
     expect do
-      object.should_not be_same_as(other)
+      expect(object).to_not be_same_as(other)
     end.to raise_error(<<-End.strip_heredoc.chomp)
          expected: {Address id: nil, name: nil, address: "A Street", city: nil, state: nil, postal_code: nil, country: nil}
 to not be same_as: {Address id: nil, name: nil, address: "A Street", city: nil, state: nil, postal_code: nil, country: nil}

--- a/spec/same_as_spec.rb
+++ b/spec/same_as_spec.rb
@@ -8,18 +8,18 @@ describe Address do
       a = Address.new(address: '123 A Street')
       b = Address.new(address: '345 K Street')
 
-      a.should_not be_same_as(b)
-      a.attributes.should_not == b.attributes
-      a.attributes_without_ignored_attributes.should_not == b.attributes_without_ignored_attributes
+      expect(a).to_not be_same_as(b)
+      expect(a.attributes).to_not eq(b.attributes)
+      expect(a.attributes_without_ignored_attributes).to_not eq(b.attributes_without_ignored_attributes)
     end
 
     it 'should still return true even if some of the ignored attributes differ' do
       a = Address.new(name: 'A', address: 'The Same Address')
       b = Address.new(name: 'B', address: 'The Same Address')
 
-      a.should be_same_as(b)
-      a.attributes.should_not == b.attributes
-      a.attributes_without_ignored_attributes.should == b.attributes_without_ignored_attributes
+      expect(a).to be_same_as(b)
+      expect(a.attributes).to_not eq(b.attributes)
+      expect(a.attributes_without_ignored_attributes).to eq(b.attributes_without_ignored_attributes)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'yaml'
+require 'byebug'
+
 __DIR__ = Pathname.new(__FILE__).dirname
 $LOAD_PATH.unshift __DIR__
 $LOAD_PATH.unshift __DIR__ + '../lib'

--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -6,7 +6,7 @@ ActiveRecord::Schema.define do
     t.string   :state
     t.string   :postal_code
     t.string   :country
-    t.timestamps
+    t.timestamps null:false
   end
 end
 


### PR DESCRIPTION
- Removes deprecation warnings present in 0.4 version when used with RSpec 2.x
- All existing RSpec tests updated to work with RSpec 3.x
- Includes byebug for debugging in development mode
